### PR TITLE
Tentative fix for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - "pypy"
+  - "pypy-5.3.1"
   - "pypy3"
 env:
   - DJANGO="Django>=1.8,<1.9"

--- a/django_fakery/compat.py
+++ b/django_fakery/compat.py
@@ -1,4 +1,5 @@
 import sys
+from django.core.exceptions import ImproperlyConfigured
 
 
 try:
@@ -22,5 +23,5 @@ else:
 try:
     from django.contrib.gis.geos.libgeos import geos_version_info
     HAS_GEOS = geos_version_info()['version'] >= '3.3.0'
-except (ImportError, OSError):
+except (ImproperlyConfigured, ImportError, OSError):
     HAS_GEOS = False


### PR DESCRIPTION
Hello,

I'm upgrading a django python2 codebase to python3 (3.6.2).

When running tests (using py.test) I get the following error:
```
ImproperlyConfigured: Could not find the GDAL library (tried "gdal", "GDAL", "gdal2.1.0", "gdal2.0.0", "gdal1.11.0", "gdal1.10.0", "gdal1.9.0"). Is GDAL installed? If it is, try setting GDAL_LIBRARY_PATH in your settings.
```

It stems from the `compat.py` try/catch. Modifiying it like this pull request makes it work but I can't help thinking that I'm missing something.