### PR TITLE
Make fields() update instead of overwriting

### DIFF
--- a/django_fakery/blueprint.py
+++ b/django_fakery/blueprint.py
@@ -23,10 +23,17 @@ class Blueprint(Generic[T]):
 
     def fields(self, **kwargs):
         # type: (**Any) -> "Blueprint"
-        self._fields = kwargs
-        return self
+        return Blueprint(
+            model=self._model,
+            fields=dict(self._fields, **kwargs),
+            pre_save=self.pre_save,
+            post_save=self.post_save,
+            seed=self.seed,
+        )
 
-    def make_one(self, fields=None, pre_save=None, post_save=None, seed=None, iteration=None):
+    def make_one(
+        self, fields=None, pre_save=None, post_save=None, seed=None, iteration=None
+    ):
         # type: (Opt[FieldMap], Opt[SaveHooks], Opt[SaveHooks], Opt[Seed], Opt[int]) -> T
         _fields = self._fields.copy()
         if fields:
@@ -83,7 +90,9 @@ class Blueprint(Generic[T]):
         # type: (Opt[FieldMap], Opt[SaveHooks], Opt[Seed], int, bool) -> List[Built]
         pass
 
-    def build(self, fields=None, pre_save=None, seed=None, quantity=None, make_fks=False):
+    def build(
+        self, fields=None, pre_save=None, seed=None, quantity=None, make_fks=False
+    ):
         _fields = self._fields.copy()
         if fields:
             _fields.update(fields)
@@ -132,7 +141,13 @@ class Blueprint(Generic[T]):
         pass
 
     def b(self, pre_save=None, seed=None, quantity=None, make_fks=False):
-        build = partial(self.build, pre_save=pre_save, seed=seed, quantity=quantity, make_fks=make_fks)
+        build = partial(
+            self.build,
+            pre_save=pre_save,
+            seed=seed,
+            quantity=quantity,
+            make_fks=make_fks,
+        )
 
         def fn(**kwargs):
             return build(fields=kwargs)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -47,6 +47,16 @@ class BlueprintTest(TestCase):
             "chef should still be set from the previous blueprint",
         )
 
+    def test_blueprint_fields_make_with_fields(self):
+        """check that blueprint.fields(...).make(fields=...) works as expected"""
+        p = pizza.fields(thickness=3).make(fields={"thickness": 5})
+        self.assertEqual(p.thickness, 5)
+
+    def test_blueprint_fields_make_one_with_fields(self):
+        """check that blueprint.fields(...).make_one(fields=...) works as expected"""
+        p = pizza.fields(thickness=3).make_one(fields={"thickness": 5})
+        self.assertEqual(p.thickness, 5)
+
 
 class BlueprintShortTest(TestCase):
     def test_blueprint(self):

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -38,6 +38,15 @@ class BlueprintTest(TestCase):
         self.assertEqual(movie_night[0].thickness, 2)
         self.assertEqual(movie_night[1].thickness, 2)
 
+    def test_blueprint_fields_returns_copy_with_updated_fields(self):
+        thick_pizzas = pizza.fields(thickness=3).build(quantity=3)
+        self.assertEqual(thick_pizzas[0].thickness, 3, "thickness should be udpated")
+        self.assertEqual(
+            thick_pizzas[1].chef.first_name,
+            "Chef 1",
+            "chef should still be set from the previous blueprint",
+        )
+
 
 class BlueprintShortTest(TestCase):
     def test_blueprint(self):


### PR DESCRIPTION
This will fix #50.

This makes `Blueprint.fields()` return a new Blueprint, with updated fields, instead of overwriting the fields on the blueprint.


