### PR TITLE
Makes shortcuts a fixture

### DIFF
--- a/django_fakery/plugin.py
+++ b/django_fakery/plugin.py
@@ -1,8 +1,14 @@
 import pytest
 
 from django_fakery import factory
+from django_fakery import shortcuts as _shortcuts
 
 
 @pytest.fixture
 def fakery():
     return factory
+
+
+@pytest.fixture
+def shortcuts():
+    return _shortcuts


### PR DESCRIPTION
I end up importing `shortcuts` in almost every module.
I guess, that it would much more convenient to use:

```python
def test_with_some_date(fakery, shortcuts):
     ...
```

I hope this is a good idea :)
