### PR TITLE
Remove `six` from dependencies

### DIFF
--- a/django_fakery/utils.py
+++ b/django_fakery/utils.py
@@ -3,8 +3,6 @@ from typing import Any, List, Type, overload
 from django.apps import apps
 from django.db import models
 
-from six import string_types
-
 from .types import T
 
 
@@ -29,7 +27,7 @@ def get_model(model: T) -> T:
 
 
 def get_model(model):
-    if isinstance(model, string_types):
+    if isinstance(model, str):
         model = apps.get_model(*model.split("."))
     return model
 

--- a/django_fakery/values.py
+++ b/django_fakery/values.py
@@ -2,8 +2,6 @@ from functools import partial
 
 from django.db import models
 
-from six import string_types
-
 from . import field_mappings
 
 
@@ -33,7 +31,7 @@ class Evaluator(object):
                 return value(self.iteration, self.faker)
             else:
                 return value()
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             try:
                 return value.format(self.iteration, self.faker)
             except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     entry_points={"pytest11": ["django_fakery = django_fakery.plugin"]},
-    install_requires=["Faker>=10.0,<11.0", "Django>=3.2", "six>=1.10.1"],
+    install_requires=["Faker>=10.0,<11.0", "Django>=3.2"],
     python_requires=">=3.8",
     test_suite="tests.runtests.runtests",
 )

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -5,8 +5,6 @@ from unittest import skipIf
 
 from django.test import TestCase
 
-from six import text_type
-
 from django_fakery import factory
 from django_fakery.compat import HAS_PSYCOPG2
 
@@ -23,7 +21,7 @@ class PostgresTest(TestCase):
         gigis_special = factory.make("tests.SpecialtyPizza")
         self.assertTrue(isinstance(gigis_special.toppings, list))
         for topping in gigis_special.toppings:
-            self.assertTrue(isinstance(topping, text_type))
+            self.assertTrue(isinstance(topping, str))
 
         self.assertTrue(isinstance(gigis_special.metadata, dict))
         self.assertTrue(isinstance(gigis_special.price_range, NumericRange))


### PR DESCRIPTION
I don't think that it is needed anymore, because python2 is long gone. And it does nothing for just python3.