### PR TITLE
Faker does not have `full_name` provider

### DIFF
--- a/django_fakery/field_mappings.py
+++ b/django_fakery/field_mappings.py
@@ -184,7 +184,7 @@ mappings_names = {
     "slug": (fakes.slug, (), {"count": 3}),
     "first_name": ("first_name", (), {}),
     "last_name": ("last_name", (), {}),
-    "full_name": ("full_name", (), {}),
+    "full_name": ("name", (), {}),
     "email": ("email", (), {}),
     "created": (
         "date_time_between",


### PR DESCRIPTION
I faced this problem:

```
.venv/lib/python3.11/site-packages/django_fakery/faker_factory.py:647: in fn
    return make(fields=kwargs)
.venv/lib/python3.11/site-packages/django_fakery/faker_factory.py:585: in make
    return self.make_one(model, fields, pre_save, post_save, seed)
.venv/lib/python3.11/site-packages/django_fakery/faker_factory.py:327: in make_one
    instance, m2ms = self.build_one(
.venv/lib/python3.11/site-packages/django_fakery/faker_factory.py:191: in build_one
    value = evaluator.fake_value(model, model_field)
.venv/lib/python3.11/site-packages/django_fakery/values.py:59: in fake_value
    return self.evaluate_fake(self.mappings_names[field.name], field)
.venv/lib/python3.11/site-packages/django_fakery/values.py:48: in evaluate_fake
    func = getattr(self.faker, resolver[0])
E   AttributeError: 'Generator' object has no attribute 'full_name'
```

Bacause, it is called `name`, not `full_name`. See https://faker.readthedocs.io/en/stable/providers/faker.providers.person.html#faker.providers.person.Provider.name

Fixes #...

### What does this changes

Brief summary of the changes

### What was wrong

Description of what was the root cause of the issue.

### How this fixes it

Description of how the changes fix the issue.
